### PR TITLE
Rebuild for libxml2 2.14.4

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,12 +8,20 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_aarch64_:
-        CONFIG: linux_aarch64_
+      linux_aarch64_xml_targetlibxml2-devel:
+        CONFIG: linux_aarch64_xml_targetlibxml2-devel
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
-      linux_ppc64le_:
-        CONFIG: linux_ppc64le_
+      linux_aarch64_xml_targetlibxml2_2.14.4:
+        CONFIG: linux_aarch64_xml_targetlibxml2_2.14.4
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+      linux_ppc64le_xml_targetlibxml2-devel:
+        CONFIG: linux_ppc64le_xml_targetlibxml2-devel
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le:alma9
+      linux_ppc64le_xml_targetlibxml2_2.14.4:
+        CONFIG: linux_ppc64le_xml_targetlibxml2_2.14.4
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le:alma9
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,12 +8,20 @@ jobs:
     vmImage: $(VMIMAGE)
   strategy:
     matrix:
-      osx_64_:
-        CONFIG: osx_64_
+      osx_64_xml_targetlibxml2-devel:
+        CONFIG: osx_64_xml_targetlibxml2-devel
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
-      osx_arm64_:
-        CONFIG: osx_arm64_
+      osx_64_xml_targetlibxml2_2.14.4:
+        CONFIG: osx_64_xml_targetlibxml2_2.14.4
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15
+      osx_arm64_xml_targetlibxml2-devel:
+        CONFIG: osx_arm64_xml_targetlibxml2-devel
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15
+      osx_arm64_xml_targetlibxml2_2.14.4:
+        CONFIG: osx_arm64_xml_targetlibxml2_2.14.4
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
   timeoutInMinutes: 360

--- a/.ci_support/linux_64_xml_targetlibxml2-devel.yaml
+++ b/.ci_support/linux_64_xml_targetlibxml2-devel.yaml
@@ -15,15 +15,15 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 libcurl:
 - '8'
-libxml2:
-- '2.14'
 openssl:
 - '3.5'
 target_platform:
-- linux-aarch64
+- linux-64
+xml_target:
+- libxml2-devel
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_xml_targetlibxml2_2.14.4.yaml
+++ b/.ci_support/linux_64_xml_targetlibxml2_2.14.4.yaml
@@ -1,0 +1,29 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+libcurl:
+- '8'
+openssl:
+- '3.5'
+target_platform:
+- linux-64
+xml_target:
+- libxml2 2.14.4
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_xml_targetlibxml2-devel.yaml
+++ b/.ci_support/linux_aarch64_xml_targetlibxml2-devel.yaml
@@ -15,15 +15,15 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le:alma9
+- quay.io/condaforge/linux-anvil-aarch64:alma9
 libcurl:
 - '8'
-libxml2:
-- '2.14'
 openssl:
 - '3.5'
 target_platform:
-- linux-ppc64le
+- linux-aarch64
+xml_target:
+- libxml2-devel
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_xml_targetlibxml2_2.14.4.yaml
+++ b/.ci_support/linux_aarch64_xml_targetlibxml2_2.14.4.yaml
@@ -1,0 +1,29 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma9
+libcurl:
+- '8'
+openssl:
+- '3.5'
+target_platform:
+- linux-aarch64
+xml_target:
+- libxml2 2.14.4
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_xml_targetlibxml2-devel.yaml
+++ b/.ci_support/linux_ppc64le_xml_targetlibxml2-devel.yaml
@@ -1,33 +1,29 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '19'
+- '14'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '19'
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le:alma9
 libcurl:
 - '8'
-libxml2:
-- '2.14'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 openssl:
 - '3.5'
 target_platform:
-- osx-64
+- linux-ppc64le
+xml_target:
+- libxml2-devel
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_xml_targetlibxml2_2.14.4.yaml
+++ b/.ci_support/linux_ppc64le_xml_targetlibxml2_2.14.4.yaml
@@ -1,0 +1,29 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le:alma9
+libcurl:
+- '8'
+openssl:
+- '3.5'
+target_platform:
+- linux-ppc64le
+xml_target:
+- libxml2 2.14.4
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_xml_targetlibxml2-devel.yaml
+++ b/.ci_support/osx_64_xml_targetlibxml2-devel.yaml
@@ -1,0 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+libcurl:
+- '8'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+openssl:
+- '3.5'
+target_platform:
+- osx-64
+xml_target:
+- libxml2-devel
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_xml_targetlibxml2_2.14.4.yaml
+++ b/.ci_support/osx_64_xml_targetlibxml2_2.14.4.yaml
@@ -20,14 +20,14 @@ cxx_compiler_version:
 - '19'
 libcurl:
 - '8'
-libxml2:
-- '2.14'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 openssl:
 - '3.5'
 target_platform:
-- osx-arm64
+- osx-64
+xml_target:
+- libxml2 2.14.4
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_arm64_xml_targetlibxml2-devel.yaml
+++ b/.ci_support/osx_arm64_xml_targetlibxml2-devel.yaml
@@ -1,0 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+libcurl:
+- '8'
+macos_machine:
+- arm64-apple-darwin20.0.0
+openssl:
+- '3.5'
+target_platform:
+- osx-arm64
+xml_target:
+- libxml2-devel
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_xml_targetlibxml2_2.14.4.yaml
+++ b/.ci_support/osx_arm64_xml_targetlibxml2_2.14.4.yaml
@@ -1,29 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '14'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '14'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 libcurl:
 - '8'
-libxml2:
-- '2.14'
+macos_machine:
+- arm64-apple-darwin20.0.0
 openssl:
 - '3.5'
 target_platform:
-- linux-64
+- osx-arm64
+xml_target:
+- libxml2 2.14.4
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -22,7 +22,12 @@ jobs:
       max-parallel: 50
       matrix:
         include:
-          - CONFIG: linux_64_
+          - CONFIG: linux_64_xml_targetlibxml2-devel
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_64_xml_targetlibxml2_2.14.4
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']

--- a/README.md
+++ b/README.md
@@ -31,38 +31,73 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64</td>
+              <td>linux_64_xml_targetlibxml2-devel</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21373&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lastpass-cli-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lastpass-cli-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_xml_targetlibxml2-devel" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64</td>
+              <td>linux_64_xml_targetlibxml2_2.14.4</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21373&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lastpass-cli-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lastpass-cli-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_xml_targetlibxml2_2.14.4" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le</td>
+              <td>linux_aarch64_xml_targetlibxml2-devel</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21373&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lastpass-cli-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lastpass-cli-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_xml_targetlibxml2-devel" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64</td>
+              <td>linux_aarch64_xml_targetlibxml2_2.14.4</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21373&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lastpass-cli-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lastpass-cli-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_xml_targetlibxml2_2.14.4" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64</td>
+              <td>linux_ppc64le_xml_targetlibxml2-devel</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21373&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lastpass-cli-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lastpass-cli-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_xml_targetlibxml2-devel" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_xml_targetlibxml2_2.14.4</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21373&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lastpass-cli-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_xml_targetlibxml2_2.14.4" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_xml_targetlibxml2-devel</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21373&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lastpass-cli-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_xml_targetlibxml2-devel" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_xml_targetlibxml2_2.14.4</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21373&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lastpass-cli-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_xml_targetlibxml2_2.14.4" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_xml_targetlibxml2-devel</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21373&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lastpass-cli-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_xml_targetlibxml2-devel" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_xml_targetlibxml2_2.14.4</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21373&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lastpass-cli-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_xml_targetlibxml2_2.14.4" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+xml_target:
+  - libxml2 2.14.4
+  - libxml2-devel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 5e4ff5c9fef8aa924547c565c44e5b4aa31e63d642873847b8e40ce34558a5e1
 
 build:
-  number: 2
+  number: 3
   # Skip windows build, but upstream supports windows
   skip: true  # [win]
 
@@ -20,13 +20,13 @@ requirements:
     - {{ stdlib('c') }}
     - {{ compiler('cxx') }}
     - asciidoc  # [not win]
-    - libxml2-devel   # [not win]
+    - {{ xml_target }}   # [not win]
     - cmake
     - make
     - pkg-config
   host:
     - libcurl
-    - libxml2-devel
+    - {{ xml_target }}
     - openssl
 
 test:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

libxml2 switched to concrete package names like "libxml2-16" in order to match the SONAME. I am not sure solvers regard them as compatible. Try to additionally build against a version of libxml2 2.14 before this change landed.